### PR TITLE
Delegate Functions Names changed and Indentation fixed

### DIFF
--- a/SwiftTemplate/Shared/Models/NewUserResponse.swift
+++ b/SwiftTemplate/Shared/Models/NewUserResponse.swift
@@ -29,11 +29,11 @@ struct User: Codable {
     
     
     enum CodingKeys: String, CodingKey {
-           case name, email, password
-           case roleID = "role_id"
-           case updatedAt = "updated_at"
-           case createdAt = "created_at"
-           case id
-       }
-
+        case name, email, password
+        case roleID = "role_id"
+        case updatedAt = "updated_at"
+        case createdAt = "created_at"
+        case id
+    }
+    
 }

--- a/SwiftTemplate/SignUp/ViewModel/SignUpViewModel.swift
+++ b/SwiftTemplate/SignUp/ViewModel/SignUpViewModel.swift
@@ -10,8 +10,8 @@ import UIKit
 
 
 protocol RegisterDelegate {
-    func showSuccessMessage(newUserResponse: NewUserResponse)
-    func showErrorAtRegister()
+    func registerNewUserSuccess(newUserResponse: NewUserResponse)
+    func registerNewUserError()
 }
 
 
@@ -27,9 +27,9 @@ class SignUpViewModel {
     
     func register(user: NewUser) {
         self.service.addNewUser(user: user) { response in
-            self.delegate?.showSuccessMessage(newUserResponse: response)
+            self.delegate?.registerNewUserSuccess(newUserResponse: response)
         } onError: {
-            self.delegate?.showErrorAtRegister()
+            self.delegate?.registerNewUserError()
         }
 
     }


### PR DESCRIPTION
## Summary:
- I changed the name of the two functions of RegisterDelegate
- Fixed the Indentation in NewUserResponse swift file

## Evidence
<img width="851" alt="Captura de Pantalla 2022-06-30 a la(s) 18 37 01" src="https://user-images.githubusercontent.com/69824165/176782413-928843b8-033c-48a7-ba7c-c2643a733ae4.png">


<img width="598" alt="Captura de Pantalla 2022-06-30 a la(s) 18 36 46" src="https://user-images.githubusercontent.com/69824165/176782471-20dfb46f-2742-42d8-92bc-52cb301acd0e.png">
